### PR TITLE
feat: #RBACK-117, kubernetes compatibility

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -16,4 +16,9 @@ pipeline {
         }
       }
     }
+    stage('Build image') {
+      steps {
+        sh 'edifice image --archs=linux/amd64 --force'
+      }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.edifice</groupId>
         <artifactId>app-parent</artifactId>
-        <version>1.0.1</version>
+        <version>1.2.0</version>
     </parent>
 
     <groupId>fr.openent</groupId>
@@ -28,14 +28,12 @@
     </scm>
 
     <properties>
-        <webUtilsVersion>3.1-SNAPSHOT</webUtilsVersion>
-        <entCoreVersion>6.7-SNAPSHOT</entCoreVersion>
+        <entCoreVersion>6.13-SNAPSHOT</entCoreVersion>
         <toolsVersion>2.0.0-final</toolsVersion>
         <junitVersion>5.1.0</junitVersion>
         <vertxCronTimerVersion>3.0-SNAPSHOT</vertxCronTimerVersion>
         <powerMockVersion>2.0.2</powerMockVersion>
         <mockitoVersion>[2.0,3.0)</mockitoVersion>
-        <gatlingHighchartsVersion>2.2.2</gatlingHighchartsVersion>
         <reflectionsVersion>0.10.2</reflectionsVersion>
     </properties>
 
@@ -116,12 +114,6 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
             <version>${powerMockVersion}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gatling.highcharts</groupId>
-            <artifactId>gatling-charts-highcharts</artifactId>
-            <version>${gatlingHighchartsVersion}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/fr/openent/flashquizz/FlashquizzConnector.java
+++ b/src/main/java/fr/openent/flashquizz/FlashquizzConnector.java
@@ -4,6 +4,7 @@ import fr.openent.flashquizz.config.FlashquizzConfig;
 import fr.openent.flashquizz.controller.FlashquizzController;
 import fr.openent.flashquizz.service.ServiceFactory;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import org.entcore.common.http.BaseServer;
 import org.entcore.common.neo4j.Neo4j;
@@ -14,16 +15,19 @@ public class FlashquizzConnector extends BaseServer {
 
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
-        super.start(startPromise);
-        
+        final Promise<Void> promise = Promise.promise();
+        super.start(promise);
+        promise.future()
+            .compose(e -> initFlashquizz())
+            .onFailure(th -> log.error("[Flashquizz-Connector@FlashquizzConnector::start] Failed to start Flashquizz module.", th))
+            .onComplete(startPromise);
+    }
+
+    public Future<Void> initFlashquizz() {
         FlashquizzConfig flashquizzConfig = new FlashquizzConfig(config);
         this.serviceFactory = new ServiceFactory(vertx, Neo4j.getInstance(), flashquizzConfig);
-        
-        addController(new FlashquizzController(serviceFactory));
-        
-        startPromise.tryComplete();
-        startPromise.tryFail("[Flashquizz-Connector@FlashquizzConnector::start] Failed to start Flashquizz module.");
-        
-        vertx.deployVerticle(SsoFlashquizz.class, new DeploymentOptions().setConfig(config));
+        return addController(new FlashquizzController(serviceFactory))
+            .compose(e -> vertx.deployVerticle(SsoFlashquizz.class, new DeploymentOptions().setConfig(config)))
+            .mapEmpty();
     }
 }


### PR DESCRIPTION
## Describe your changes
Ajout de la compatibilité avec un déploiement dans Kubernetes :
- le démarrage du Verticle a été modifié afin de bien prendre en compte l'instanciation de BaseServer
- mise à jour du pom parent
- mise à jour de la dépendance vers entcore
- suppresion de la dépendance envers gatling qui n'est pas utilisé
- construction de l'image dans le pipeline Jenkins

## Checklist tests

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)